### PR TITLE
Guard against missing HUD elements and fit canvas to viewport

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -6,7 +6,7 @@
 */
 :root { --bg:#121212; --fg:#e5e5e5; --accent:#4ade80; }
 * { box-sizing: border-box; }
-html, body { height:100%; margin:0; background:var(--bg); color:var(--fg); font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji","Segoe UI Emoji"; }
+html, body { height:100%; margin:0; overflow:hidden; background:var(--bg); color:var(--fg); font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji","Segoe UI Emoji"; }
 .wrap { display:flex; flex-direction:column; height:100%; }
 
 header { position:fixed; top:10px; left:50%; transform:translateX(-50%); z-index:5; }


### PR DESCRIPTION
## Summary
- log clear errors when HUD elements are missing before updating text
- scale simulation canvas to fit the window so Safari shows the whole scene
- prevent scrollbars by hiding page overflow
- expand canvas sizing to use viewport dimensions and react to visualViewport changes
- cap canvas scaling when viewport is larger than the world to avoid undefined visualViewport errors
- fall back to document dimensions when visualViewport is unavailable
- use optional chaining with innerWidth/innerHeight fallback for safe scaling calculation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_689c23f990b483319bfd70c64e45daab