### PR TITLE
fix: scale canvas to fill screen

### DIFF
--- a/main.js
+++ b/main.js
@@ -86,7 +86,7 @@ function resizeCanvas() {
   // Calcula escala para ajustar la simulación al tamaño de la ventana
   const worldPxW = WORLD_W * TILE;
   const worldPxH = WORLD_H * TILE;
-  const scale = Math.min(window.innerWidth / worldPxW, window.innerHeight / worldPxH, 1);
+  const scale = Math.min(window.innerWidth / worldPxW, window.innerHeight / worldPxH);
 
   // Ajusta el tamaño visible del lienzo respetando la relación de aspecto
   const cssW = worldPxW * scale;

--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,7 @@
 :root { --bg:#121212; --fg:#e5e5e5; --accent:#4ade80; }
 * { box-sizing: border-box; }
 html, body { height:100%; margin:0; overflow:hidden; background:var(--bg); color:var(--fg); font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji","Segoe UI Emoji"; }
-.wrap { display:flex; flex-direction:column; height:100%; }
+.wrap { display:flex; flex-direction:column; align-items:center; justify-content:center; height:100%; }
 
 header { position:fixed; top:10px; left:50%; transform:translateX(-50%); z-index:5; }
 #hud { background:rgba(0,0,0,0.5); padding:6px 10px; border-radius:8px; display:flex; gap:12px; align-items:center; }


### PR DESCRIPTION
## Summary
- allow canvas scaling beyond base resolution to fill the screen
- center simulation canvas in viewport via flexbox

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c30dde8b08331864bdd1f8552e919