### PR TITLE
feat: add crowding counters and penalties

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,6 +40,17 @@ const plant = new Float32Array(WORLD_W * WORLD_H);
 const terrain = new Uint8Array(WORLD_W * WORLD_H);
 const soilMoisture = new Float32Array(WORLD_W * WORLD_H);
 
+// Per-tile crowding counters grouped by size class
+const crowdSmall = new Float32Array(WORLD_W * WORLD_H);
+const crowdMedium = new Float32Array(WORLD_W * WORLD_H);
+const crowdLarge = new Float32Array(WORLD_W * WORLD_H);
+
+// Size thresholds and crowding control parameters
+const SMALL_LIMIT = 0.30;      // radius < SMALL_LIMIT => small
+const LARGE_LIMIT = 0.36;      // radius >= LARGE_LIMIT => large
+const CROWD_THRESH = { small:6, medium:4, large:2 };
+const CROWD_DECAY = 0.6;       // decay factor applied each step
+
 // Configuración de especies y poblaciones iniciales
 // Cada especie define parámetros básicos y dieta de recursos o presas
 const speciesConfig = {
@@ -570,6 +581,8 @@ const state = {
   triggerFireCenter, strikeMeteor, plague,
   toolbar, cvs, ctx,
   sprites,
+  crowdSmall, crowdMedium, crowdLarge,
+  CROWD_THRESH, CROWD_DECAY, SMALL_LIMIT, LARGE_LIMIT,
   terrainCanvas:null,
   redrawTerrain:true,
   grid, GRID_SIZE, GRID_W, GRID_H, cellIndex,

--- a/physics.js
+++ b/physics.js
@@ -14,7 +14,18 @@ export function step(state, dt){
     state.growPlants();
   }
 
-  // Rebuild spatial grid for faster neighborhood queries
+  // Decay previous crowding information
+  const totalTiles = state.WORLD_W * state.WORLD_H;
+  const cSmall = state.crowdSmall;
+  const cMed = state.crowdMedium;
+  const cLarge = state.crowdLarge;
+  for (let i=0;i<totalTiles;i++){
+    cSmall[i] *= state.CROWD_DECAY;
+    cMed[i] *= state.CROWD_DECAY;
+    cLarge[i] *= state.CROWD_DECAY;
+  }
+
+  // Rebuild spatial grid and populate crowding counters for current positions
   const grid = state.grid;
   for (let i=0;i<grid.length;i++) grid[i].length = 0;
   for (const a of state.animals){
@@ -22,6 +33,11 @@ export function step(state, dt){
     const gy = Math.floor(a.y / state.GRID_SIZE);
     const gi = state.cellIndex(gx,gy);
     grid[gi].push(a);
+
+    const ti = state.idx(Math.floor(a.x), Math.floor(a.y));
+    if (a.r < state.SMALL_LIMIT) cSmall[ti] += 1;
+    else if (a.r < state.LARGE_LIMIT) cMed[ti] += 1;
+    else cLarge[ti] += 1;
   }
 
   for (let i=state.animals.length-1; i>=0; i--){
@@ -44,6 +60,25 @@ export function step(state, dt){
     const threat = state.nearestPredator(a, vision);
     const prey = state.nearestPrey(a, vision);
 
+    const tx = Math.floor(a.x);
+    const ty = Math.floor(a.y);
+    const tid = state.idx(tx, ty);
+    let crowdCount, crowdThresh, crowdArr;
+    if (a.r < state.SMALL_LIMIT){
+      crowdCount = cSmall[tid];
+      crowdThresh = state.CROWD_THRESH.small;
+      crowdArr = cSmall;
+    } else if (a.r < state.LARGE_LIMIT){
+      crowdCount = cMed[tid];
+      crowdThresh = state.CROWD_THRESH.medium;
+      crowdArr = cMed;
+    } else {
+      crowdCount = cLarge[tid];
+      crowdThresh = state.CROWD_THRESH.large;
+      crowdArr = cLarge;
+    }
+    const overcrowded = crowdCount > crowdThresh;
+
     if (threat){
       const ang = Math.atan2(a.y - threat.y, a.x - threat.x);
       a.dir = ang + (Math.random()-0.5)*0.6;
@@ -52,6 +87,25 @@ export function step(state, dt){
       a.dir = ang + (Math.random()-0.5)*0.2;
     } else {
       a.dir += (Math.random()-0.5) * a.wobble * dt * (cfg.wanderFactor || 1.5);
+    }
+
+    // Bias movement away from crowded tiles
+    if (overcrowded){
+      const neigh = [[1,0],[-1,0],[0,1],[0,-1]];
+      let bestAng = null;
+      let best = crowdCount;
+      for (const [dx,dy] of neigh){
+        const nx = state.clamp(tx+dx, 0, state.WORLD_W-1);
+        const ny = state.clamp(ty+dy, 0, state.WORLD_H-1);
+        const c = crowdArr[state.idx(nx,ny)];
+        if (c < best){
+          best = c;
+          bestAng = Math.atan2(dy,dx);
+        }
+      }
+      if (bestAng !== null){
+        a.dir = a.dir*0.7 + bestAng*0.3;
+      }
     }
 
     state.moveCreature(a, dt, effSpeed);
@@ -66,9 +120,13 @@ export function step(state, dt){
     }
 
     if (a.energy > cfg.reproThreshold && a.cooldown<=0){
-      state.reproduce(a, a.sp);
-      a.energy -= cfg.reproCost;
-      a.cooldown = cfg.reproCooldown;
+      let chance = 1;
+      if (overcrowded) chance *= crowdThresh / crowdCount;
+      if (Math.random() < chance){
+        state.reproduce(a, a.sp);
+        a.energy -= cfg.reproCost;
+        a.cooldown = cfg.reproCooldown;
+      }
     }
 
     if (a.energy <= 0){ state.animals.splice(i,1); }


### PR DESCRIPTION
## Summary
- track per-tile animal counts by size class with decay
- reduce reproduction and steer movement away from crowded tiles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c3af4581083319e090ed478475a4c