### PR TITLE
feat: expand species and pollination mechanics

### DIFF
--- a/physics.js
+++ b/physics.js
@@ -113,8 +113,8 @@ export function step(state, dt){
     state.eatPlant(a);
 
     if (prey && state.dist2(a, prey) < (a.r*state.TILE + prey.r*state.TILE) * (a.r*state.TILE + prey.r*state.TILE)){
-      const diet = cfg.diet[prey.sp];
-      if (diet) a.energy += diet.energy;
+      const dietEntry = cfg.diet[prey.sp];
+      if (dietEntry) a.energy += state.speciesConfig[prey.sp].preyEnergy;
       const idxPrey = state.animals.indexOf(prey);
       if (idxPrey !== -1) state.animals.splice(idxPrey,1);
     }

--- a/sprites.js
+++ b/sprites.js
@@ -96,6 +96,42 @@ function carnFrame(offset){
   });
 }
 
+function rodentFrame(offset){
+  return makeCanvas(16,16,(ctx)=>{
+    ctx.fillStyle = '#a3a3a3';
+    ctx.beginPath();
+    ctx.arc(8,8,4,0,Math.PI*2);
+    ctx.fill();
+    ctx.fillStyle = '#525252';
+    ctx.fillRect(4+offset,12,2,2);
+    ctx.fillRect(10-offset,12,2,2);
+  });
+}
+
+function wolfFrame(offset){
+  return makeCanvas(16,16,(ctx)=>{
+    ctx.fillStyle = '#9ca3af';
+    ctx.beginPath();
+    ctx.arc(8,8,5,0,Math.PI*2);
+    ctx.fill();
+    ctx.fillStyle = '#4b5563';
+    ctx.fillRect(4+offset,12,3,3);
+    ctx.fillRect(9-offset,12,3,3);
+  });
+}
+
+function pollinatorFrame(offset){
+  return makeCanvas(16,16,(ctx)=>{
+    ctx.fillStyle = '#c084fc';
+    ctx.beginPath();
+    ctx.arc(8,8,3,0,Math.PI*2);
+    ctx.fill();
+    ctx.fillStyle = '#9333ea';
+    ctx.fillRect(4+offset,12,2,2);
+    ctx.fillRect(10-offset,12,2,2);
+  });
+}
+
 export const sprites = {
   terrain: {
     water: texWater(),
@@ -105,5 +141,8 @@ export const sprites = {
   },
   plant: makePlant(),
   herb: [herbFrame(0), herbFrame(2)],
-  carn: [carnFrame(0), carnFrame(2)]
+  carn: [carnFrame(0), carnFrame(2)],
+  rodent: [rodentFrame(0), rodentFrame(2)],
+  wolf: [wolfFrame(0), wolfFrame(2)],
+  pollinator: [pollinatorFrame(0), pollinatorFrame(2)]
 };


### PR DESCRIPTION
## Summary
- extend speciesConfig with speed, hunger, vision, preyEnergy, fecundity, size and lifespan attributes
- add rodent, wolf and pollinator species with dedicated diets and sprites
- pollinator movement boosts nearby plant growth and predators draw energy from preyEnergy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c3c17ca248331a190134c4923f02a