### PR TITLE
Add species control panel with runtime tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,48 @@
         <span id="weather">Clima: --</span>
         <span id="tick">t: 0.0s</span>
       </div>
+      <div id="speciesPanel">
+        <div class="sp" data-sp="HERB">
+          <span class="icon">🐇</span>
+          <label title="Permitir spawn"><input type="checkbox" class="spawn-toggle" checked>spawn</label>
+          <label title="Mostrar"><input type="checkbox" class="vis-toggle" checked>ver</label>
+          <input type="range" class="spawnRate" min="0" max="2" step="0.1" value="1" title="spawnRate" />
+          <input type="range" class="reproThresholdMul" min="0.5" max="2" step="0.1" value="1" title="reproThresholdMul" />
+          <input type="range" class="mortalityMul" min="0.5" max="2" step="0.1" value="1" title="mortalityMul" />
+        </div>
+        <div class="sp" data-sp="CARN">
+          <span class="icon">🦊</span>
+          <label title="Permitir spawn"><input type="checkbox" class="spawn-toggle" checked>spawn</label>
+          <label title="Mostrar"><input type="checkbox" class="vis-toggle" checked>ver</label>
+          <input type="range" class="spawnRate" min="0" max="2" step="0.1" value="1" title="spawnRate" />
+          <input type="range" class="reproThresholdMul" min="0.5" max="2" step="0.1" value="1" title="reproThresholdMul" />
+          <input type="range" class="mortalityMul" min="0.5" max="2" step="0.1" value="1" title="mortalityMul" />
+        </div>
+        <div class="sp" data-sp="RODENT">
+          <span class="icon">🐀</span>
+          <label title="Permitir spawn"><input type="checkbox" class="spawn-toggle" checked>spawn</label>
+          <label title="Mostrar"><input type="checkbox" class="vis-toggle" checked>ver</label>
+          <input type="range" class="spawnRate" min="0" max="2" step="0.1" value="1" title="spawnRate" />
+          <input type="range" class="reproThresholdMul" min="0.5" max="2" step="0.1" value="1" title="reproThresholdMul" />
+          <input type="range" class="mortalityMul" min="0.5" max="2" step="0.1" value="1" title="mortalityMul" />
+        </div>
+        <div class="sp" data-sp="WOLF">
+          <span class="icon">🐺</span>
+          <label title="Permitir spawn"><input type="checkbox" class="spawn-toggle" checked>spawn</label>
+          <label title="Mostrar"><input type="checkbox" class="vis-toggle" checked>ver</label>
+          <input type="range" class="spawnRate" min="0" max="2" step="0.1" value="1" title="spawnRate" />
+          <input type="range" class="reproThresholdMul" min="0.5" max="2" step="0.1" value="1" title="reproThresholdMul" />
+          <input type="range" class="mortalityMul" min="0.5" max="2" step="0.1" value="1" title="mortalityMul" />
+        </div>
+        <div class="sp" data-sp="POLLINATOR">
+          <span class="icon">🐝</span>
+          <label title="Permitir spawn"><input type="checkbox" class="spawn-toggle" checked>spawn</label>
+          <label title="Mostrar"><input type="checkbox" class="vis-toggle" checked>ver</label>
+          <input type="range" class="spawnRate" min="0" max="2" step="0.1" value="1" title="spawnRate" />
+          <input type="range" class="reproThresholdMul" min="0.5" max="2" step="0.1" value="1" title="reproThresholdMul" />
+          <input type="range" class="mortalityMul" min="0.5" max="2" step="0.1" value="1" title="mortalityMul" />
+        </div>
+      </div>
     </header>
 
     <div class="toolbar" id="toolbar">

--- a/main.js
+++ b/main.js
@@ -163,6 +163,13 @@ const speciesConfig = {
 // Array dinámico de individuos; cada uno es un objeto con estado y genes
 const animals = [];
 
+const speciesList = Object.keys(speciesConfig);
+const spawnEnabled = Object.fromEntries(speciesList.map(s=>[s,true]));
+const hiddenSpecies = Object.fromEntries(speciesList.map(s=>[s,false]));
+const spawnRate = Object.fromEntries(speciesList.map(s=>[s,1]));
+const reproThresholdMul = Object.fromEntries(speciesList.map(s=>[s,1]));
+const mortalityMul = Object.fromEntries(speciesList.map(s=>[s,1]));
+
 // Spatial grid for neighborhood queries (optimizes nearest searches)
 const GRID_SIZE = 10; // tiles per cell
 const GRID_W = Math.ceil(WORLD_W / GRID_SIZE);
@@ -612,6 +619,8 @@ const state = {
   TILE, WORLD_W, WORLD_H,
   animals, plant, terrain, soilMoisture,
   speciesConfig,
+  spawnEnabled, hiddenSpecies,
+  spawnRate, reproThresholdMul, mortalityMul,
   idx, clamp, WEATHER, WEATHER_NAMES, BIOME, COLORS,
   TOOL, defaultGenes, advanceWeather, growPlants, isNight,
   nearestPredator, nearestPrey, moveCreature, clampInside,

--- a/physics.js
+++ b/physics.js
@@ -53,7 +53,7 @@ export function step(state, dt){
     const visionNightMul = night ? (cfg.nightVisionMul || 1.0) : 1.0;
 
     const effSpeed = (a.speed * a.genes.speedMul) * speedNightMul;
-    const hungerRate = cfg.hungerRate * a.genes.metabolismMul;
+    const hungerRate = cfg.hungerRate * a.genes.metabolismMul * (state.mortalityMul[a.sp] || 1);
 
     a.energy -= hungerRate * dt;
     const vision = (cfg.vision * a.genes.visionMul) * visionNightMul;
@@ -119,9 +119,11 @@ export function step(state, dt){
       if (idxPrey !== -1) state.animals.splice(idxPrey,1);
     }
 
-    if (a.energy > cfg.reproThreshold && a.cooldown<=0){
-      let chance = 1;
+    const thresh = cfg.reproThreshold * (state.reproThresholdMul[a.sp] || 1);
+    if (a.energy > thresh && a.cooldown<=0 && state.spawnEnabled[a.sp]){
+      let chance = state.spawnRate[a.sp] || 1;
       if (overcrowded) chance *= crowdThresh / crowdCount;
+      chance = Math.min(1, Math.max(0, chance));
       if (Math.random() < chance){
         state.reproduce(a, a.sp);
         a.energy -= cfg.reproCost;

--- a/render.js
+++ b/render.js
@@ -39,6 +39,7 @@ export function render(state){
   // Animated animal sprites
   const frame = Math.floor(state.simTime*6)%2;
   for(const a of animals){
+    if (state.hiddenSpecies[a.sp]) continue;
     const imgSet = sprites[a.sp.toLowerCase()] || sprites.herb;
     const img = imgSet[frame];
     const size = a.r*2*TILE;

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,9 @@ header { position:fixed; top:10px; left:50%; transform:translateX(-50%); z-index
 .stat { font-variant-numeric:tabular-nums; }
 #debugPanel { margin-top:8px; background:rgba(0,0,0,0.6); padding:6px 10px; border-radius:8px; display:flex; gap:10px; font-size:12px; }
 .hidden { display:none; }
+#speciesPanel { margin-top:8px; background:rgba(0,0,0,0.6); padding:6px 10px; border-radius:8px; display:flex; flex-direction:column; gap:4px; font-size:12px; }
+#speciesPanel .sp { display:flex; align-items:center; gap:4px; }
+#speciesPanel .icon { width:16px; }
 
 .toolbar { position:fixed; left:10px; top:50%; transform:translateY(-50%); display:flex; flex-direction:column; gap:8px; background:rgba(0,0,0,0.4); padding:8px; border-radius:12px; z-index:5; }
 .toolbar .divider { height:1px; background:rgba(255,255,255,0.2); margin:4px 0; }

--- a/ui.js
+++ b/ui.js
@@ -94,4 +94,21 @@ export function setupUI(state){
   document.getElementById('evtMeteor').addEventListener('click', state.strikeMeteor);
   document.getElementById('evtPlagueH').addEventListener('click', ()=> state.plague('HERB',0.35));
   document.getElementById('evtPlagueC').addEventListener('click', ()=> state.plague('CARN',0.5));
+
+  const panel = document.getElementById('speciesPanel');
+  if (panel){
+    panel.querySelectorAll('.sp').forEach(row=>{
+      const sp = row.dataset.sp;
+      const spawnT = row.querySelector('.spawn-toggle');
+      const visT = row.querySelector('.vis-toggle');
+      const sRate = row.querySelector('.spawnRate');
+      const rMul = row.querySelector('.reproThresholdMul');
+      const mMul = row.querySelector('.mortalityMul');
+      if (spawnT) spawnT.addEventListener('change',()=> state.spawnEnabled[sp] = spawnT.checked);
+      if (visT) visT.addEventListener('change',()=> state.hiddenSpecies[sp] = !visT.checked);
+      if (sRate) sRate.addEventListener('input',()=> state.spawnRate[sp] = parseFloat(sRate.value));
+      if (rMul) rMul.addEventListener('input',()=> state.reproThresholdMul[sp] = parseFloat(rMul.value));
+      if (mMul) mMul.addEventListener('input',()=> state.mortalityMul[sp] = parseFloat(mMul.value));
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- Add species panel with emoji legends, spawn/show toggles, and sliders for spawnRate, reproThresholdMul, and mortalityMul
- Wire UI controls to update species parameters during simulation
- Honor spawn controls in physics and hide toggled species in render

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c3e5ff1688331a6c9a3f3c9a6feef