### PR TITLE
Make simulation canvas responsive to viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
       <button class="btn" id="evtPlagueC" title="Plaga carnívoros">🦠C</button>
     </div>
 
-    <canvas id="sim" width="1000" height="600"></canvas>
+    <canvas id="sim"></canvas>
   </div>
 
   <script type="module" src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -188,22 +188,18 @@ const cvs = document.getElementById('sim');
 const ctx = cvs.getContext('2d', { alpha:false });
 
 function resizeCanvas() {
-  // Calcula escala para ajustar la simulación al tamaño de la ventana
   const worldPxW = WORLD_W * TILE;
   const worldPxH = WORLD_H * TILE;
+
+  // Tamaño real del canvas acorde a la ventana y densidad de píxeles
+  cvs.width = Math.floor(window.innerWidth * DPR);
+  cvs.height = Math.floor(window.innerHeight * DPR);
+
+  // Escala para ajustar el mundo al tamaño visible
   const scale = Math.min(window.innerWidth / worldPxW, window.innerHeight / worldPxH);
 
-  // Ajusta el tamaño visible del lienzo respetando la relación de aspecto
-  const cssW = worldPxW * scale;
-  const cssH = worldPxH * scale;
-  cvs.style.width = cssW + 'px';
-  cvs.style.height = cssH + 'px';
-
-  // Mantiene el buffer interno a resolución completa para nitidez y escala vía CSS
-  cvs.width = Math.floor(worldPxW * DPR);
-  cvs.height = Math.floor(worldPxH * DPR);
   ctx.imageSmoothingEnabled = false;           // Look pixel-art
-  ctx.setTransform(DPR, 0, 0, DPR, 0, 0);      // 1 unidad lógica = 1 px del mundo
+  ctx.setTransform(scale * DPR, 0, 0, scale * DPR, 0, 0);
 }
 resizeCanvas();
 window.addEventListener('resize', resizeCanvas);

--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,7 @@
 :root { --bg:#121212; --fg:#e5e5e5; --accent:#4ade80; }
 * { box-sizing: border-box; }
 html, body { height:100%; margin:0; overflow:hidden; background:var(--bg); color:var(--fg); font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji","Segoe UI Emoji"; }
-.wrap { display:flex; flex-direction:column; align-items:center; justify-content:center; height:100%; }
+.wrap { width:100vw; height:100vh; }
 
 header { position:fixed; top:10px; left:50%; transform:translateX(-50%); z-index:5; }
 #hud { background:rgba(0,0,0,0.5); padding:6px 10px; border-radius:8px; display:flex; gap:12px; align-items:center; }
@@ -25,6 +25,6 @@ header { position:fixed; top:10px; left:50%; transform:translateX(-50%); z-index
 .btn.active { border-color:var(--accent); box-shadow:0 0 0 2px var(--accent) inset; }
 .btn.danger { border-color:#f87171; color:#fecaca; }
 
-canvas { width:100%; height:auto; display:block; background:#000; image-rendering:pixelated; }
+canvas { width:100vw; height:100vh; display:block; background:#000; image-rendering:pixelated; }
 .tests { position:fixed; right:10px; top:10px; background:rgba(0,0,0,0.6); border:1px solid rgba(255,255,255,0.2); border-radius:10px; padding:8px 10px; font-size:12px; color:var(--fg); box-shadow:0 6px 20px rgba(0,0,0,.25); z-index:10; }
 .tests b { color:var(--accent); }


### PR DESCRIPTION
## Summary
- Remove fixed canvas dimensions to allow responsive layout
- Expand canvas to fill viewport via CSS and unrestrict wrapping container
- Scale rendering context on resize to match window dimensions and device pixel ratio

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c43263e588331ad4e78828b8846c0