### PR TITLE
Add base UI layout with HUD, minimap and radial menu

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Simulador de Ecosistemas</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito&family=Poppins&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles/main.css" />
+</head>
+<body>
+  <header id="hud"></header>
+  <aside id="sidebar"></aside>
+  <div id="minimap"></div>
+  <div id="radialMenu"></div>
+  <canvas id="worldCanvas"></canvas>
+  <script type="module" src="../main.js"></script>
+</body>
+</html>

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -1,0 +1,30 @@
+/*
+  ===== Estilos base y responsive mínimos =====
+  - Paleta oscura, tipografía del sistema
+  - Layout fluido con contenedor centrado
+  - Botones de toolbar con estados activos
+*/
+:root { --bg:#121212; --fg:#e5e5e5; --accent:#4ade80; }
+* { box-sizing: border-box; }
+html, body { height:100%; margin:0; overflow:hidden; background:var(--bg); color:var(--fg); font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji","Segoe UI Emoji"; }
+.wrap { width:100vw; height:100vh; }
+
+header { position:fixed; top:10px; left:50%; transform:translateX(-50%); z-index:5; }
+#hud { background:rgba(0,0,0,0.5); padding:6px 10px; border-radius:8px; display:flex; gap:12px; align-items:center; }
+.stat { font-variant-numeric:tabular-nums; }
+#debugPanel { margin-top:8px; background:rgba(0,0,0,0.6); padding:6px 10px; border-radius:8px; display:flex; gap:10px; font-size:12px; }
+.hidden { display:none; }
+#speciesPanel { margin-top:8px; background:rgba(0,0,0,0.6); padding:6px 10px; border-radius:8px; display:flex; flex-direction:column; gap:4px; font-size:12px; }
+#speciesPanel .sp { display:flex; align-items:center; gap:4px; }
+#speciesPanel .icon { width:16px; }
+
+.toolbar { position:fixed; left:10px; top:50%; transform:translateY(-50%); display:flex; flex-direction:column; gap:8px; background:rgba(0,0,0,0.4); padding:8px; border-radius:12px; z-index:5; }
+.toolbar .divider { height:1px; background:rgba(255,255,255,0.2); margin:4px 0; }
+.btn { background:rgba(0,0,0,0.6); border:1px solid rgba(255,255,255,0.2); color:var(--fg); width:44px; height:44px; border-radius:10px; font-size:22px; line-height:1; display:flex; align-items:center; justify-content:center; cursor:pointer; transition:transform .1s, background .1s; }
+.btn:hover { transform:scale(1.1); background:rgba(255,255,255,0.1); }
+.btn.active { border-color:var(--accent); box-shadow:0 0 0 2px var(--accent) inset; }
+.btn.danger { border-color:#f87171; color:#fecaca; }
+
+canvas { width:100vw; height:100vh; display:block; background:#000; image-rendering:pixelated; }
+.tests { position:fixed; right:10px; top:10px; background:rgba(0,0,0,0.6); border:1px solid rgba(255,255,255,0.2); border-radius:10px; padding:8px 10px; font-size:12px; color:var(--fg); box-shadow:0 6px 20px rgba(0,0,0,.25); z-index:10; }
+.tests b { color:var(--accent); }


### PR DESCRIPTION
## Summary
- Add minimal public index with HUD header, sidebar, minimap, radial menu and world canvas
- Include Google Fonts (Poppins and Nunito) and link to main stylesheet
- Copy existing styles into public/styles/main.css for consistent look

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca222a35c83318af4012dd2eaaf16