### PR TITLE
Add HUD initialization and update utilities

### DIFF
--- a/hud.js
+++ b/hud.js
@@ -1,0 +1,79 @@
+export function initHUD(state) {
+  const hud = document.getElementById('hud');
+  if (!hud) return;
+
+  const playBtn = document.createElement('button');
+  playBtn.id = 'playPause';
+  playBtn.textContent = '⏸️';
+  hud.appendChild(playBtn);
+
+  const clock = document.createElement('span');
+  clock.id = 'hudClock';
+  clock.title = 'Hora';
+  hud.appendChild(clock);
+
+  const weather = document.createElement('span');
+  weather.id = 'hudWeather';
+  weather.title = 'Clima';
+  hud.appendChild(weather);
+
+  const herb = document.createElement('span');
+  herb.className = 'stat';
+  herb.title = 'Herbívoros';
+  herb.appendChild(document.createTextNode('🐇 '));
+  const herbCount = document.createElement('span');
+  herbCount.id = 'herbCount';
+  herbCount.textContent = '0';
+  herb.appendChild(herbCount);
+  hud.appendChild(herb);
+
+  const carn = document.createElement('span');
+  carn.className = 'stat';
+  carn.title = 'Carnívoros';
+  carn.appendChild(document.createTextNode('🦊 '));
+  const carnCount = document.createElement('span');
+  carnCount.id = 'carnCount';
+  carnCount.textContent = '0';
+  carn.appendChild(carnCount);
+  hud.appendChild(carn);
+
+  const plant = document.createElement('span');
+  plant.className = 'stat';
+  plant.title = 'Plantas densas';
+  plant.appendChild(document.createTextNode('🌿 '));
+  const plantCount = document.createElement('span');
+  plantCount.id = 'plantCount';
+  plantCount.textContent = '0';
+  plant.appendChild(plantCount);
+  hud.appendChild(plant);
+
+  playBtn.addEventListener('click', () => {
+    state.paused = !state.paused;
+    playBtn.textContent = state.paused ? '▶️' : '⏸️';
+  });
+
+  state.hud = { playBtn, clock, weather, herbCount, carnCount, plantCount };
+}
+
+export function updateHUD(state) {
+  const hud = state.hud;
+  if (!hud) return;
+
+  const herb = state.animals.filter(a => a.sp === 'HERB').length;
+  const carn = state.animals.filter(a => a.sp === 'CARN').length;
+  let plants = 0;
+  for (let i = 0; i < state.terrain.length; i++) {
+    if (state.terrain[i] === state.BIOME.GRASS && state.plant[i] > 0.33) plants++;
+  }
+  hud.herbCount.textContent = herb;
+  hud.carnCount.textContent = carn;
+  hud.plantCount.textContent = plants;
+
+  const dayT = (state.worldTime % state.DAY_LENGTH_SEC) / state.DAY_LENGTH_SEC;
+  const hours = Math.floor(dayT * 24);
+  const mins = Math.floor((dayT * 24 - hours) * 60);
+  hud.clock.textContent = `${String(hours).padStart(2, '0')}:${String(mins).padStart(2, '0')}`;
+
+  const icons = ['☀️', '🌧️', '🔥'];
+  hud.weather.textContent = icons[state.weatherState] || '';
+}

--- a/index.html
+++ b/index.html
@@ -5,16 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Simulador de Ecosistemas</title>
   <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="public/styles/hud.css">
 </head>
 <body>
   <div class="wrap">
     <header>
-      <div id="hud">
-        <span class="stat" title="Herbívoros">🐇 <span id="herbCount">0</span></span>
-        <span class="stat" title="Carnívoros">🦊 <span id="carnCount">0</span></span>
-        <span class="stat" title="Plantas densas">🌿 <span id="plantCount">0</span></span>
-        <button id="debugBtn" title="Mostrar info avanzada">⚙️</button>
-      </div>
+      <div id="hud"></div>
+      <button id="debugBtn" title="Mostrar info avanzada">⚙️</button>
       <div id="debugPanel" class="hidden">
         <span id="fps">FPS: --</span>
         <span id="clock">Hora: --:--</span>


### PR DESCRIPTION
## Summary
- build dynamic HUD with play/pause control
- update main loop to refresh HUD stats and support pausing
- load dedicated HUD styles in the page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ca49da83483318958ac98609f6609