### PR TITLE
Add toggleable sidebar with persistent sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Simulador de Ecosistemas</title>
   <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles/sidebar.css">
   <link rel="stylesheet" href="public/styles/hud.css">
 </head>
 <body>
@@ -61,6 +62,8 @@
         </div>
       </div>
     </header>
+
+    <div id="sidebar"></div>
 
     <div class="toolbar" id="toolbar">
       <button class="btn" data-tool="inspect" title="Inspeccionar">🔍</button>

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ import { render } from './render.js';
 import { setupUI, setTool, applyActionAt } from './ui.js';
 import { sprites } from './sprites.js';
 import { initHUD, updateHUD } from './hud.js';
+import { initSidebar } from './sidebar.js';
 // ==============================================================
 //                    PARÁMETROS DEL MUNDO
 // ==============================================================
@@ -540,6 +541,7 @@ const TOOL = { INSPECT:'inspect', ADD_HERB:'add_herb', ADD_CARN:'add_carn', ERAS
 
 // Toolbar DOM
 const toolbar = document.getElementById('toolbar');
+const sidebar = document.getElementById('sidebar');
 
 // Atajos y entrada gestionados en ui.js
 
@@ -610,7 +612,7 @@ const state = {
   nearestOfSpecies, moveCreature, clampInside,
   eatPlant, reproduce, dist2, daylightFactor,
   triggerFireCenter, strikeMeteor, plague,
-  toolbar, cvs, ctx,
+  toolbar, sidebar, cvs, ctx,
   sprites,
   crowdSmall, crowdMedium, crowdLarge,
   CROWD_THRESH, CROWD_DECAY, SMALL_LIMIT, LARGE_LIMIT,
@@ -660,6 +662,7 @@ function loop(now){
 // ==============================================================
 setupUI(state);
 initHUD(state);
+initSidebar(state);
 generateTerrain();                 // Crea el mapa base
 generateSoilMoisture();            // Inicializa humedad del suelo
 spawnAnimals();                    // Población inicial

--- a/sidebar.js
+++ b/sidebar.js
@@ -1,0 +1,47 @@
+export function initSidebar(state){
+  const sidebar = document.getElementById('sidebar');
+  if(!sidebar) return;
+  state.sidebar = sidebar;
+
+  const sections = [
+    {
+      id: 'info',
+      title: 'Información',
+      content: `<p>Tiempo sim: <span id="sb-simTime">0</span>s</p>`
+    },
+    {
+      id: 'ayuda',
+      title: 'Ayuda',
+      content: `<p>Usa la barra de herramientas para interactuar con el mundo.</p>`
+    }
+  ];
+
+  const detailElements = [];
+  sections.forEach(sec => {
+    const details = document.createElement('details');
+    details.dataset.section = sec.id;
+    const summary = document.createElement('summary');
+    summary.textContent = sec.title;
+    const panel = document.createElement('div');
+    panel.className = 'panel';
+    panel.innerHTML = sec.content;
+    details.appendChild(summary);
+    details.appendChild(panel);
+
+    if (localStorage.getItem(`sidebar-${sec.id}`) === '1') {
+      details.open = true;
+    }
+
+    details.addEventListener('toggle', () => {
+      if (details.open) {
+        detailElements.forEach(d => { if (d !== details) d.open = false; });
+      }
+      localStorage.setItem(`sidebar-${sec.id}`, details.open ? '1' : '0');
+    });
+
+    sidebar.appendChild(details);
+    detailElements.push(details);
+  });
+
+  state.sidebarPanels = sidebar.querySelectorAll('.panel');
+}

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -1,0 +1,30 @@
+#sidebar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 220px;
+  height: 100%;
+  padding: 8px;
+  background: rgba(0,0,0,0.4);
+  overflow-y: auto;
+  z-index: 6;
+}
+
+#sidebar details {
+  margin-bottom: 8px;
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 6px;
+  background: rgba(0,0,0,0.3);
+}
+
+#sidebar summary {
+  cursor: pointer;
+  padding: 6px 8px;
+  font-weight: bold;
+  list-style: none;
+}
+
+#sidebar .panel {
+  padding: 6px 8px;
+  font-size: 14px;
+}


### PR DESCRIPTION
## Summary
- add sidebar initialization with `<details>` sections and localStorage persistence
- create contextual panels and link new sidebar stylesheet
- style sidebar via `styles/sidebar.css`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ca64c4e3883318ee98e61414c3a94