### PR TITLE
Add radial menu UI with numeric shortcuts

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -49,3 +49,49 @@ body { position:relative; }
   width:180px;
   height:180px;
 }
+
+#radialMenu {
+  position:absolute;
+  bottom:20px;
+  left:50%;
+  transform:translateX(-50%);
+}
+
+#radialMenu .radial-btn {
+  width:56px;
+  height:56px;
+  border-radius:50%;
+  border:none;
+  background:var(--accent);
+  color:var(--bg);
+  font-size:28px;
+  cursor:pointer;
+}
+
+#radialMenu .radial-options {
+  position:absolute;
+  top:50%;
+  left:50%;
+  transform:translate(-50%,-50%);
+  display:none;
+}
+
+#radialMenu .radial-options.open {
+  display:block;
+}
+
+#radialMenu .radial-options button {
+  position:absolute;
+  width:44px;
+  height:44px;
+  border-radius:50%;
+  border:none;
+  background:rgba(0,0,0,0.6);
+  color:var(--fg);
+  cursor:pointer;
+}
+
+#radialMenu .radial-options button:nth-child(1) { transform:translate(-70px,0); }
+#radialMenu .radial-options button:nth-child(2) { transform:translate(0,-70px); }
+#radialMenu .radial-options button:nth-child(3) { transform:translate(70px,0); }
+#radialMenu .radial-options button:nth-child(4) { transform:translate(0,70px); }

--- a/src/ui/radialMenu.js
+++ b/src/ui/radialMenu.js
@@ -1,0 +1,35 @@
+export function initRadialMenu(container, options, holdMs = 500) {
+  const root = typeof container === 'string' ? document.querySelector(container) : container;
+  if (!root) return;
+
+  const center = document.createElement('button');
+  center.className = 'radial-btn';
+  center.textContent = '\u2630';
+  root.appendChild(center);
+
+  const menu = document.createElement('div');
+  menu.className = 'radial-options';
+  options.forEach(opt => {
+    const btn = document.createElement('button');
+    btn.textContent = opt.label;
+    btn.addEventListener('click', () => {
+      opt.onSelect();
+      hide();
+    });
+    menu.appendChild(btn);
+  });
+  root.appendChild(menu);
+
+  let timer;
+  function show() { menu.classList.add('open'); }
+  function hide() { menu.classList.remove('open'); }
+  function cancel() { clearTimeout(timer); hide(); }
+
+  const start = () => { timer = setTimeout(show, holdMs); };
+
+  center.addEventListener('mousedown', start);
+  center.addEventListener('touchstart', start);
+  center.addEventListener('mouseup', cancel);
+  center.addEventListener('mouseleave', cancel);
+  center.addEventListener('touchend', cancel);
+}

--- a/ui.js
+++ b/ui.js
@@ -1,3 +1,5 @@
+import { initRadialMenu } from './src/ui/radialMenu.js';
+
 export function setTool(state, t){
   state.activeTool = t;
   for (const btn of state.toolbar.querySelectorAll('button[data-tool]'))
@@ -71,7 +73,8 @@ function nearestAnimalTo(state,x,y,maxR){
 }
 
 export function setupUI(state){
-  state.toolbar.querySelectorAll('button[data-tool]').forEach(btn=>{
+  const toolButtons = Array.from(state.toolbar.querySelectorAll('button[data-tool]'));
+  toolButtons.forEach(btn=>{
     btn.addEventListener('click', ()=> setTool(state, btn.dataset.tool));
   });
 
@@ -82,9 +85,10 @@ export function setupUI(state){
   state.cvs.addEventListener('click', e=>{ if(!dragging) handleAt(state,e); });
 
   window.addEventListener('keydown', (e)=>{
-    const map = { '1':'inspect','2':'add_herb','3':'eraser','4':'food','5':'water','6':'barrier' };
-    if(map[e.key]) setTool(state, map[e.key]);
-    else if(e.key==='f' || e.key==='F') state.triggerFireCenter();
+    const num = parseInt(e.key,10);
+    if(num>=1 && num<=toolButtons.length){
+      setTool(state, toolButtons[num-1].dataset.tool);
+    } else if(e.key==='f' || e.key==='F') state.triggerFireCenter();
     else if(e.key==='m' || e.key==='M') state.strikeMeteor();
     else if(e.key==='p' || e.key==='P') state.plague('HERB',0.35);
     else if(e.key==='o' || e.key==='O') state.plague('CARN',0.5);
@@ -94,6 +98,16 @@ export function setupUI(state){
   document.getElementById('evtMeteor').addEventListener('click', state.strikeMeteor);
   document.getElementById('evtPlagueH').addEventListener('click', ()=> state.plague('HERB',0.35));
   document.getElementById('evtPlagueC').addEventListener('click', ()=> state.plague('CARN',0.5));
+
+  const radialRoot = document.getElementById('radialMenu');
+  if(radialRoot){
+    initRadialMenu(radialRoot,[
+      { label:'\uD83D\uDD0D', onSelect:()=> setTool(state, state.TOOL.INSPECT) },
+      { label:'\uD83D\uDC07', onSelect:()=> setTool(state, state.TOOL.ADD_HERB) },
+      { label:'\uD83E\uDD8A', onSelect:()=> setTool(state, state.TOOL.ADD_CARN) },
+      { label:'\uD83C\uDF3F', onSelect:()=> setTool(state, state.TOOL.FOOD) }
+    ]);
+  }
 
   const panel = document.getElementById('speciesPanel');
   if (panel){


### PR DESCRIPTION
## Summary
- add radial menu component that reveals options on long press
- wire radial menu and dynamic numeric hotkeys into UI setup
- style and position radial menu button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689caa38579883318ab64c3e78f3326c