### PR TITLE
feat: add animated main menu

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ import { sprites } from './sprites.js';
 import { initHUD, updateHUD } from './hud.js';
 import { initSidebar } from './sidebar.js';
 import { initMinimap, updateMinimap } from './minimap.js';
+import { initMainMenu } from './src/ui/mainMenu.js';
 let state;
 // ==============================================================
 //                    PARÁMETROS DEL MUNDO
@@ -669,6 +670,7 @@ function loop(now){
 // ==============================================================
 //                           INIT
 // ==============================================================
+initMainMenu(state);
 setupUI(state);
 initHUD(state);
 initSidebar(state);

--- a/public/index.html
+++ b/public/index.html
@@ -11,8 +11,10 @@
   <link rel="stylesheet" href="styles/hud.css" />
   <link rel="stylesheet" href="styles/sidebar.css" />
   <link rel="stylesheet" href="styles/minimap.css" />
+  <link rel="stylesheet" href="styles/mainMenu.css" />
 </head>
 <body>
+  <div id="mainMenu"></div>
   <header id="hud"></header>
   <aside id="sidebar"></aside>
   <div id="minimap"></div>

--- a/public/styles/mainMenu.css
+++ b/public/styles/mainMenu.css
@@ -1,0 +1,48 @@
+#mainMenu {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: linear-gradient(-45deg, #1e3a8a, #2563eb, #22d3ee, #3b82f6);
+  background-size: 400% 400%;
+  animation: menuBg 15s ease infinite;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+  z-index: 1000;
+}
+
+#mainMenu.show {
+  opacity: 1;
+}
+
+#mainMenu.hide {
+  opacity: 0;
+  pointer-events: none;
+}
+
+#mainMenu button {
+  margin: 0.5rem;
+  padding: 0.75rem 2rem;
+  font-size: 1.2rem;
+  font-family: 'Poppins', sans-serif;
+  cursor: pointer;
+  border: none;
+  border-radius: 4px;
+  background: rgba(255,255,255,0.9);
+  transition: transform 0.2s;
+}
+
+#mainMenu button:hover {
+  transform: scale(1.05);
+}
+
+@keyframes menuBg {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}

--- a/src/ui/mainMenu.js
+++ b/src/ui/mainMenu.js
@@ -1,0 +1,31 @@
+export function initMainMenu(state){
+  const root = document.getElementById('mainMenu');
+  if(!root) return;
+
+  const buttons = [
+    { label: 'Jugar', action: 'play' },
+    { label: 'Opciones', action: 'options' },
+    { label: 'Tutorial', action: 'tutorial' },
+    { label: 'Cr\u00E9ditos', action: 'credits' }
+  ];
+
+  buttons.forEach(b => {
+    const btn = document.createElement('button');
+    btn.textContent = b.label;
+    btn.dataset.action = b.action;
+    root.appendChild(btn);
+  });
+
+  requestAnimationFrame(() => root.classList.add('show'));
+
+  const playBtn = root.querySelector('button[data-action="play"]');
+  if(playBtn){
+    playBtn.addEventListener('click', () => {
+      root.classList.add('hide');
+      state.paused = false;
+      setTimeout(() => root.remove(), 500);
+    });
+  }
+
+  state.paused = true;
+}


### PR DESCRIPTION
## Summary
- add animated main menu overlay with play/options/tutorial/credits buttons
- pause simulation until play is pressed
- style main menu with dynamic gradient and fade animations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cab89b9008331ac0bb30411435ddb