### PR TITLE
Fix canvas ID mismatch between HTML and script

### DIFF
--- a/main.js
+++ b/main.js
@@ -199,7 +199,7 @@ const clamp = (v, a, b)=> Math.max(a, Math.min(b, v)); // Limita v al rango [a,b
 // ==============================================================
 //                         CANVAS SETUP
 // ==============================================================
-const cvs = document.getElementById('sim');
+const cvs = document.getElementById('worldCanvas');
 const ctx = cvs.getContext('2d', { alpha:false });
 
 let camX = 0, camY = 0, scale = 1;


### PR DESCRIPTION
## Summary
- Align main.js to use the existing `worldCanvas` element.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cb35ecef483319eaedf511a024973