### PR TITLE
Fix GSAP import path

### DIFF
--- a/hud.js
+++ b/hud.js
@@ -1,4 +1,4 @@
-import { gsap } from 'gsap';
+import { gsap } from 'https://cdn.jsdelivr.net/npm/gsap@3.13.0/index.js';
 import { saveSettings } from './src/state/persistence.js';
 
 export function initHUD(state) {

--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ import { initSidebar } from './sidebar.js';
 import { initMinimap, updateMinimap } from './minimap.js';
 import { initMainMenu } from './src/ui/mainMenu.js';
 import { loadSettings, saveSettings } from './src/state/persistence.js';
-import { gsap } from 'gsap';
+import { gsap } from 'https://cdn.jsdelivr.net/npm/gsap@3.13.0/index.js';
 let state;
 // ==============================================================
 //                    PARÁMETROS DEL MUNDO


### PR DESCRIPTION
## Summary
- load GSAP from CDN to avoid browser module resolution error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c452e0f848331ada15a9b6f2bb21c