### PR TITLE
Handle missing canvas element

### DIFF
--- a/hud.js
+++ b/hud.js
@@ -1,4 +1,4 @@
-import { gsap } from 'gsap';
+import { gsap } from 'https://cdn.jsdelivr.net/npm/gsap@3.13.0/index.js';
 import { saveSettings } from './src/state/persistence.js';
 
 export function initHUD(state) {

--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ import { initSidebar } from './sidebar.js';
 import { initMinimap, updateMinimap } from './minimap.js';
 import { initMainMenu } from './src/ui/mainMenu.js';
 import { loadSettings, saveSettings } from './src/state/persistence.js';
-import { gsap } from 'gsap';
+import { gsap } from 'https://cdn.jsdelivr.net/npm/gsap@3.13.0/index.js';
 let state;
 // ==============================================================
 //                    PARÁMETROS DEL MUNDO
@@ -199,7 +199,11 @@ const clamp = (v, a, b)=> Math.max(a, Math.min(b, v)); // Limita v al rango [a,b
 // ==============================================================
 //                         CANVAS SETUP
 // ==============================================================
-const cvs = document.getElementById('worldCanvas');
+const cvs = document.getElementById('sim');
+if (!cvs) {
+  console.error('Canvas element with id "sim" not found');
+  throw new Error('Canvas element with id "sim" not found');
+}
 const ctx = cvs.getContext('2d', { alpha:false });
 
 let camX = 0, camY = 0, scale = 1;

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
   <aside id="sidebar"></aside>
   <div id="minimap"></div>
   <div id="radialMenu"></div>
-  <canvas id="worldCanvas"></canvas>
+  <canvas id="sim"></canvas>
   <script type="module" src="../main.js"></script>
 </body>
 </html>

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -17,7 +17,7 @@ html, body {
   font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji","Segoe UI Emoji";
 }
 body { position:relative; }
-#worldCanvas {
+#sim {
   width:100%;
   height:100%;
   display:block;


### PR DESCRIPTION
## Summary
- load GSAP from CDN to avoid browser module resolution error
- guard against a missing canvas and use a consistent `sim` id across HTML and CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c452e0f848331ada15a9b6f2bb21c