### PR TITLE
Add toggle for species panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,8 @@
         <span id="weather">Clima: --</span>
         <span id="tick">t: 0.0s</span>
       </div>
-      <div id="speciesPanel">
+      <button id="speciesBtn" title="Mostrar panel de especies">🐾</button>
+      <div id="speciesPanel" class="hidden">
         <div class="sp" data-sp="HERB">
           <span class="icon">🐇</span>
           <label title="Permitir spawn"><input type="checkbox" class="spawn-toggle" checked>spawn</label>

--- a/main.js
+++ b/main.js
@@ -684,6 +684,10 @@ const debugPanel = document.getElementById('debugPanel');
 document.getElementById('debugBtn').addEventListener('click', () => debugPanel.classList.toggle('hidden'));
 window.addEventListener('keydown', e=>{ if(e.key==='d' || e.key==='D') debugPanel.classList.toggle('hidden'); });
 
+const speciesPanel = document.getElementById('speciesPanel');
+const speciesBtn = document.getElementById('speciesBtn');
+speciesBtn.addEventListener('click', () => speciesPanel.classList.toggle('hidden'));
+
 function loop(now){
   if (state.paused){ last = now; requestAnimationFrame(loop); return; }
   const dt = Math.min(0.05, (now - last)/1000); // Delta tiempo con tope (50ms) para estabilidad

--- a/styles.css
+++ b/styles.css
@@ -29,6 +29,7 @@ header { position:fixed; top:10px; left:50%; transform:translateX(-50%); z-index
 #debugPanel { margin-top:8px; background:rgba(0,0,0,0.6); padding:6px 10px; border-radius:8px; display:flex; gap:10px; font-size:12px; transition:box-shadow .3s, background .3s, transform .3s; animation:panelFade .6s ease-out; }
   .hidden { display:none; }
 #speciesPanel { margin-top:8px; background:rgba(0,0,0,0.6); padding:6px 10px; border-radius:8px; display:flex; flex-direction:column; gap:4px; font-size:12px; transition:box-shadow .3s, background .3s, transform .3s; animation:panelFade .6s ease-out; }
+#speciesPanel.hidden { display:none; }
 #speciesPanel .sp { display:flex; align-items:center; gap:4px; }
 #speciesPanel .icon { width:16px; }
 


### PR DESCRIPTION
## Summary
- Add species button and hide species panel by default
- Toggle species panel visibility via button
- Ensure hidden class hides species panel correctly

## Testing
- `CI=true npm test -- --runInBand --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_689d04bfbd1483318c983410ed9c7c82