### PR TITLE
feat: support independent axis scaling

### DIFF
--- a/main.js
+++ b/main.js
@@ -209,7 +209,7 @@ if (!ctx) {
   throw new Error('Unable to acquire 2D context for canvas');
 }
 
-let camX = 0, camY = 0, scale = 1;
+let camX = 0, camY = 0, scaleX = 1, scaleY = 1;
 
 function resizeCanvas() {
   const worldPxW = WORLD_W * TILE;
@@ -220,11 +220,12 @@ function resizeCanvas() {
   cvs.height = Math.floor(window.innerHeight * DPR);
 
   // Escala para ajustar el mundo al tamaño visible
-  scale = Math.min(window.innerWidth / worldPxW, window.innerHeight / worldPxH);
+  scaleX = window.innerWidth / worldPxW;
+  scaleY = window.innerHeight / worldPxH;
 
   ctx.imageSmoothingEnabled = false;           // Look pixel-art
-  ctx.setTransform(scale * DPR, 0, 0, scale * DPR, -camX * TILE * scale * DPR, -camY * TILE * scale * DPR);
-  if (state) state.scale = scale;
+  ctx.setTransform(scaleX * DPR, 0, 0, scaleY * DPR, -camX * TILE * scaleX * DPR, -camY * TILE * scaleY * DPR);
+  if (state) { state.scaleX = scaleX; state.scaleY = scaleY; }
 }
 resizeCanvas();
 window.addEventListener('resize', resizeCanvas);
@@ -646,8 +647,14 @@ state = {
   eatPlant, reproduce, dist2, daylightFactor,
   triggerFireCenter, strikeMeteor, plague,
   toolbar, cvs, ctx,
-  camX, camY, scale, DPR,
-  applyCamera(){ camX = state.camX; camY = state.camY; resizeCanvas(); },
+  camX, camY, scaleX, scaleY, DPR,
+  applyCamera(){
+    camX = state.camX;
+    camY = state.camY;
+    scaleX = state.scaleX;
+    scaleY = state.scaleY;
+    ctx.setTransform(scaleX * DPR, 0, 0, scaleY * DPR, -camX * TILE * scaleX * DPR, -camY * TILE * scaleY * DPR);
+  },
   minimap:null,
   sprites,
   crowdSmall, crowdMedium, crowdLarge,

--- a/minimap.js
+++ b/minimap.js
@@ -11,8 +11,8 @@ export function initMinimap(state){
     const rect = cvs.getBoundingClientRect();
     const mx = (e.clientX - rect.left) / rect.width * state.WORLD_W;
     const my = (e.clientY - rect.top) / rect.height * state.WORLD_H;
-    const viewW = window.innerWidth / (state.TILE * state.scale);
-    const viewH = window.innerHeight / (state.TILE * state.scale);
+    const viewW = window.innerWidth / (state.TILE * state.scaleX);
+    const viewH = window.innerHeight / (state.TILE * state.scaleY);
     state.camX = Math.max(0, Math.min(state.WORLD_W - viewW, mx - viewW/2));
     state.camY = Math.max(0, Math.min(state.WORLD_H - viewH, my - viewH/2));
     if (state.applyCamera) state.applyCamera();


### PR DESCRIPTION
## Summary
- allow separate horizontal and vertical scale factors
- expose `scaleX`/`scaleY` on state and update minimap interactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d18f377a48331b106ad54edf0309d