### PR TITLE
Gate self tests via NODE_ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ Para generar la versión de producción:
 ```
 npm run build
 ```
+
+### Pruebas internas
+
+El simulador ejecuta pruebas internas de sanidad (`runSelfTests`) únicamente cuando
+`NODE_ENV` no es `production`.
+
+- Para habilitarlas, inicia el proyecto con `NODE_ENV=development` (valor por defecto en `npm run dev`).
+- Para inhabilitarlas, ejecuta con `NODE_ENV=production`.

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ import { initMinimap, updateMinimap } from './minimap.js';
 import { initMainMenu } from './src/ui/mainMenu.js';
 import { loadSettings, saveSettings } from './src/state/persistence.js';
 import { gsap } from 'https://cdn.jsdelivr.net/npm/gsap@3.13.0/index.js';
+const IS_DEV = process.env.NODE_ENV !== 'production';
 let state;
 // ==============================================================
 //                    PARÁMETROS DEL MUNDO
@@ -806,5 +807,5 @@ function runSelfTests(){
   tests.forEach(t=>console[t.pass? 'log': 'error'](`${t.pass?'✔':'✖'} ${t.name}${t.info? ' — '+t.info:''}`));
   console.groupEnd();
 }
-runSelfTests();
+if (IS_DEV) runSelfTests();
 


### PR DESCRIPTION
## Summary
- add `IS_DEV` from `process.env.NODE_ENV`
- run `runSelfTests` only in development
- document how to toggle self-tests in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d1fb6b1c88331b10e3bc939a4bdca