### PR TITLE
Add destroy cleanup for radial menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ Para generar la versión de producción:
 ```
 npm run build
 ```
+
+## Menú radial
+
+`initRadialMenu` devuelve una función `destroy` que remueve los listeners añadidos.
+Esto permite montar y desmontar el menú de forma dinámica sin pérdidas de memoria.
+
+```js
+const destroy = initRadialMenu('#radialMenu', opciones);
+// ... al desmontar el menú
+destroy();
+```

--- a/radialMenu.test.js
+++ b/radialMenu.test.js
@@ -1,0 +1,45 @@
+/** @jest-environment jsdom */
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let initRadialMenu;
+beforeAll(() => {
+  jest.useFakeTimers();
+  const code = fs.readFileSync(path.join(__dirname, 'src/ui/radialMenu.js'), 'utf8');
+  const transformed = code.replace('export function initRadialMenu', 'function initRadialMenu');
+  const moduleCode = `${transformed}\nmodule.exports = { initRadialMenu };`;
+  const module = { exports: {} };
+  vm.runInNewContext(moduleCode, { module, exports: module.exports, require, document: window.document, setTimeout, clearTimeout });
+  initRadialMenu = module.exports.initRadialMenu;
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+test('destroy removes event listeners from radial menu', () => {
+  document.body.innerHTML = '<div id="root"></div>';
+  const onSelect = jest.fn();
+  const destroy = initRadialMenu('#root', [{ label: 'A', onSelect }], 0);
+
+  const center = document.querySelector('#root .radial-btn');
+  const menu = document.querySelector('#root .radial-options');
+  const option = menu.querySelector('button');
+
+  center.dispatchEvent(new MouseEvent('mousedown'));
+  jest.runAllTimers();
+  expect(menu.classList.contains('open')).toBe(true);
+  option.dispatchEvent(new MouseEvent('click'));
+  expect(onSelect).toHaveBeenCalledTimes(1);
+
+  destroy();
+
+  menu.classList.remove('open');
+  center.dispatchEvent(new MouseEvent('mousedown'));
+  jest.runAllTimers();
+  expect(menu.classList.contains('open')).toBe(false);
+  option.dispatchEvent(new MouseEvent('click'));
+  expect(onSelect).toHaveBeenCalledTimes(1);
+});
+

--- a/src/ui/radialMenu.js
+++ b/src/ui/radialMenu.js
@@ -1,6 +1,22 @@
+/**
+ * Inicializa un menú radial dentro del `container` dado.
+ *
+ * Retorna una función `destroy` que elimina los listeners registrados, útil
+ * cuando el menú se monta y se desmonta dinámicamente.
+ *
+ * @param {HTMLElement|string} container
+ * @param {{label:string,onSelect:Function}[]} options
+ * @param {number} [holdMs=500]
+ * @returns {Function} destroy
+ *
+ * @example
+ * const destroy = initRadialMenu('#menu', opts);
+ * // ... al desmontar
+ * destroy();
+ */
 export function initRadialMenu(container, options, holdMs = 500) {
   const root = typeof container === 'string' ? document.querySelector(container) : container;
-  if (!root) return;
+  if (!root) return () => {};
 
   const center = document.createElement('button');
   center.className = 'radial-btn';
@@ -9,13 +25,16 @@ export function initRadialMenu(container, options, holdMs = 500) {
 
   const menu = document.createElement('div');
   menu.className = 'radial-options';
+  const optionHandlers = [];
   options.forEach(opt => {
     const btn = document.createElement('button');
     btn.textContent = opt.label;
-    btn.addEventListener('click', () => {
+    const handler = () => {
       opt.onSelect();
       hide();
-    });
+    };
+    btn.addEventListener('click', handler);
+    optionHandlers.push({ btn, handler });
     menu.appendChild(btn);
   });
   root.appendChild(menu);
@@ -32,4 +51,13 @@ export function initRadialMenu(container, options, holdMs = 500) {
   center.addEventListener('mouseup', cancel);
   center.addEventListener('mouseleave', cancel);
   center.addEventListener('touchend', cancel);
+
+  return function destroy() {
+    center.removeEventListener('mousedown', start);
+    center.removeEventListener('touchstart', start);
+    center.removeEventListener('mouseup', cancel);
+    center.removeEventListener('mouseleave', cancel);
+    center.removeEventListener('touchend', cancel);
+    optionHandlers.forEach(({ btn, handler }) => btn.removeEventListener('click', handler));
+  };
 }


### PR DESCRIPTION
## Summary
- expose `destroy` function from `initRadialMenu` to remove added event listeners
- document dynamic mount/unmount usage of `destroy`
- test radial menu cleanup behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d1fbcae2c83318e197e3084aa5247