### PR TITLE
feat: extract noise utilities and add tests

### DIFF
--- a/main.js
+++ b/main.js
@@ -17,7 +17,8 @@ import {
   GRID_SIZE, GRID_W, GRID_H, cellIndex, grid,
   idx, clamp, speciesConfig
 } from './src/worldConfig.js';
-import { generateTerrain, generateSoilMoisture, seededRandom } from './src/terrain.js';
+import { generateTerrain, generateSoilMoisture } from './src/terrain.js';
+import { seededRandom } from './src/utils/noise.js';
 import {
   getWorldTime, setWorldTime,
   getSimTime, setSimTime,

--- a/src/terrain.js
+++ b/src/terrain.js
@@ -1,48 +1,7 @@
 'use strict';
 
 import { WORLD_W, WORLD_H, BIOME, plant, terrain, soilMoisture, idx, clamp } from './worldConfig.js';
-
-export function seededRandom(seed) {
-  // PRNG congruencial lineal reproducible
-  let s = seed >>> 0;
-  return function() {
-    s = (s * 1664525 + 1013904223) >>> 0;
-    return (s & 0xfffffff) / 0xfffffff; // Devuelve [0,1)
-  };
-}
-
-function valueNoise2D(width, height, gridStep, rng){
-  // Genera ruido 2D por interpolación bilineal de una grilla de valores aleatorios
-  const gw = Math.ceil(width / gridStep)+2;
-  const gh = Math.ceil(height/ gridStep)+2;
-  const grid = new Float32Array(gw*gh);
-  for(let gy=0; gy<gh; gy++){
-    for(let gx=0; gx<gw; gx++){
-      grid[gy*gw+gx] = rng();
-    }
-  }
-  const out = new Float32Array(width*height);
-  for(let y=0; y<height; y++){
-    const gy = Math.floor(y / gridStep);
-    const fy = (y / gridStep) - gy;           // Fracción vertical entre celdas
-    for(let x=0; x<width; x++){
-      const gx = Math.floor(x / gridStep);
-      const fx = (x / gridStep) - gx;         // Fracción horizontal
-      // Cuatro esquinas de la celda
-      const a = grid[gy*gw+gx];
-      const b = grid[gy*gw+gx+1];
-      const c = grid[(gy+1)*gw+gx];
-      const d = grid[(gy+1)*gw+gx+1];
-      // Suavizado cúbico (curva S) para evitar artefactos
-      const sx = fx*fx*(3-2*fx);
-      const sy = fy*fy*(3-2*fy);
-      const i1 = a + (b-a)*sx;                // Interpola horizontal arriba
-      const i2 = c + (d-c)*sx;                // Interpola horizontal abajo
-      out[y*width+x] = i1 + (i2 - i1)*sy;     // Interpola vertical
-    }
-  }
-  return out;
-}
+import { seededRandom, valueNoise2D } from './utils/noise.js';
 
 // Construye terreno base a partir de 2 octavas de ruido
 export function generateTerrain() {

--- a/src/utils/noise.js
+++ b/src/utils/noise.js
@@ -1,0 +1,44 @@
+'use strict';
+
+export function seededRandom(seed) {
+  // PRNG congruencial lineal reproducible
+  let s = seed >>> 0;
+  return function() {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return (s & 0xfffffff) / 0xfffffff; // Devuelve [0,1)
+  };
+}
+
+export function valueNoise2D(width, height, gridStep, rng) {
+  // Genera ruido 2D por interpolación bilineal de una grilla de valores aleatorios
+  const gw = Math.ceil(width / gridStep) + 2;
+  const gh = Math.ceil(height / gridStep) + 2;
+  const grid = new Float32Array(gw * gh);
+  for (let gy = 0; gy < gh; gy++) {
+    for (let gx = 0; gx < gw; gx++) {
+      grid[gy * gw + gx] = rng();
+    }
+  }
+  const out = new Float32Array(width * height);
+  for (let y = 0; y < height; y++) {
+    const gy = Math.floor(y / gridStep);
+    const fy = (y / gridStep) - gy; // Fracción vertical entre celdas
+    for (let x = 0; x < width; x++) {
+      const gx = Math.floor(x / gridStep);
+      const fx = (x / gridStep) - gx; // Fracción horizontal
+      // Cuatro esquinas de la celda
+      const a = grid[gy * gw + gx];
+      const b = grid[gy * gw + gx + 1];
+      const c = grid[(gy + 1) * gw + gx];
+      const d = grid[(gy + 1) * gw + gx + 1];
+      // Suavizado cúbico (curva S) para evitar artefactos
+      const sx = fx * fx * (3 - 2 * fx);
+      const sy = fy * fy * (3 - 2 * fy);
+      const i1 = a + (b - a) * sx; // Interpola horizontal arriba
+      const i2 = c + (d - c) * sx; // Interpola horizontal abajo
+      out[y * width + x] = i1 + (i2 - i1) * sy; // Interpola vertical
+    }
+  }
+  return out;
+}
+

--- a/tests/noise.test.js
+++ b/tests/noise.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+let seededRandom;
+let valueNoise2D;
+
+beforeAll(() => {
+  const code = fs.readFileSync(path.join(__dirname, '..', 'src', 'utils', 'noise.js'), 'utf8');
+  const transformed = code
+    .replace('export function seededRandom', 'function seededRandom')
+    .replace('export function valueNoise2D', 'function valueNoise2D');
+  const moduleCode = `${transformed}\nmodule.exports = { seededRandom, valueNoise2D };`;
+  const module = { exports: {} };
+  vm.runInNewContext(moduleCode, { module, exports: module.exports, require });
+  ({ seededRandom, valueNoise2D } = module.exports);
+});
+
+describe('seededRandom', () => {
+  test('generates deterministic sequence within [0,1)', () => {
+    const rng1 = seededRandom(123);
+    const rng2 = seededRandom(123);
+    const seq1 = [rng1(), rng1(), rng1()];
+    const seq2 = [rng2(), rng2(), rng2()];
+    expect(seq1).toEqual(seq2);
+    for (const n of seq1) {
+      expect(n).toBeGreaterThanOrEqual(0);
+      expect(n).toBeLessThan(1);
+    }
+  });
+});
+
+describe('valueNoise2D', () => {
+  test('produces reproducible 2D noise values between 0 and 1', () => {
+    const rng1 = seededRandom(1);
+    const out1 = valueNoise2D(4, 4, 2, rng1);
+    expect(ArrayBuffer.isView(out1)).toBe(true);
+    expect(out1).toHaveLength(16);
+    for (const v of out1) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    }
+    const rng2 = seededRandom(1);
+    const out2 = valueNoise2D(4, 4, 2, rng2);
+    expect(Array.from(out1)).toEqual(Array.from(out2));
+  });
+});


### PR DESCRIPTION
## Summary
- move seededRandom and valueNoise2D into dedicated `src/utils/noise.js`
- import noise helpers from new module in terrain and main files
- add Jest tests for deterministic random and noise generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d240bfb5883319dc3e82c7c4af50a