### PR TITLE
Ejecutar self-tests solo en entornos de desarrollo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Para generar la versión de producción:
 npm run build
 ```
 
+## Self-tests
+
+El simulador ejecuta pruebas internas al arrancar para verificar su integridad. Estas *self-tests* solo se ejecutan cuando la variable de entorno `NODE_ENV` tiene un valor distinto de `production`.
+
+Para habilitarlas basta con ejecutar el entorno de desarrollo habitual (`npm run dev`). Para inhabilitarlas, establece `NODE_ENV=production` antes de iniciar el proceso, por ejemplo:
+
+```
+NODE_ENV=production npm run dev
+```
+
 ## Menú radial
 
 `initRadialMenu` devuelve una función `destroy` que remueve los listeners añadidos.

--- a/main.js
+++ b/main.js
@@ -28,6 +28,8 @@ import {
 } from './src/weather.js';
 import { runSelfTests } from './src/selfTests.js';
 
+const IS_DEV = process.env.NODE_ENV !== 'production';
+
 let state;
 
 const speciesList = Object.keys(speciesConfig);
@@ -477,4 +479,6 @@ gsap.to('#evtFire', { rotation:-10, yoyo:true, repeat:-1, duration:0.6, transfor
 gsap.to('#evtMeteor', { y:-4, yoyo:true, repeat:-1, duration:0.8 });
 gsap.to('#evtPlagueH, #evtPlagueC', { scale:1.1, yoyo:true, repeat:-1, duration:1 });
 
-runSelfTests(state, applyActionAt, TOOL, defaultGenes);
+if (IS_DEV) {
+  runSelfTests(state, applyActionAt, TOOL, defaultGenes);
+}


### PR DESCRIPTION
## Summary
- Ejecuta las self-tests únicamente cuando `NODE_ENV` no es `production`
- Documenta cómo habilitar o inhabilitar las self-tests mediante `NODE_ENV`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d25988dcc83318fd3b95999f3958e